### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/soap4r-middleware.gemspec
+++ b/soap4r-middleware.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Provides a Rack middleware for exposing SOAP server endpoints}
   s.description = %q{Sometimes, you just gotta SOAP.}
 
-  s.rubyforge_project = "soap4r-middleware"
   s.license           = 'MIT'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436